### PR TITLE
Remove temp files from ariaExtract and update readmes

### DIFF
--- a/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/ARIA_tools_Cropping_README.md
+++ b/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/ARIA_tools_Cropping_README.md
@@ -1,15 +1,8 @@
 # ARIA tools Cropping and Stitching InSAR Products
-2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, Eric Fielding, Heresh Fattahi, Gareth Funning, Franz Meyer, Simran Sangha, Zhang Yunjun
+ARIA-tools Version: v1.1.6
 
-TA’s: Becca Bussard, Niloufar Abolfathian, Brett Buzzanga, Emre Havazli
-
-ISCE Version: v2.5.2
-
-MintPy Version: v1.3.1
-
-Resource: ARIA notebook, ARIA video linked in syllabus
+Resource: ariaExtract notebook
 
 Expected Outcome: Develop a facility for exploring the Get Ready For NISAR ARIA products at the ASF, downloading processing interferograms, and manipulating interferograms to create a stack ready for time-series analysis.
 

--- a/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/ARIA_tools_stacks_README.md
+++ b/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/ARIA_tools_stacks_README.md
@@ -1,15 +1,8 @@
 # Interferogram Stacks: Temporal-spatial statistical considerations
- 2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, Eric Fielding, Heresh Fattahi, Gareth Funning, Franz Meyer, Simran Sangha, Zhang Yunjun
+ARIA-tools Version: v1.1.6
 
-TA’s: Becca Bussard, Niloufar Abolfathian, Brett Buzzanga, Emre Havazli
-
-ISCE Version: v2.5.2
-
-MintPy Version: v1.3.1
-
-Resource: ARIATSSetup, ARIA video linked in syllabus
+Resource: ariaTSsetup notebook
 
 Expected Outcome: Quick intro to ARIATSSetup, and related tools; Drill down further in time-series to an understanding of what to expect if a stack of interferograms is presented to a time-series analysis package.
 

--- a/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/README.md
+++ b/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/README.md
@@ -1,7 +1,7 @@
 # Interferogram Stacks: Temporal-spatial statistical considerations
 
-**Resource:** ARIATSSetup, ARIA video linked in syllabus
+**Resource:** ariaExtract and ariaTSsetup notebooks
 
-**Expected Outcome:** Quick intro to ARIATSsetup, and related tools; Drill down further in time-series to an understanding of what to expect if a stack of interferograms is presented to a time-series analysis package.
+**Expected Outcome:** Quick intro to ARIA standardized interferometric products and ARIA-tools; Drill down further in time-series to an understanding of what to expect if a stack of interferograms is presented to a time-series analysis package.
 
 **Assessment:** Homework #1 on stack creation

--- a/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/ariaExtract_tutorial.ipynb
+++ b/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/ariaExtract_tutorial.ipynb
@@ -1199,9 +1199,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove temp geometry files from previous runs (if they exist)\n",
+    "if os.path.exists('metadatalyr_plots'):\n",
+    "    shutil.rmtree('metadatalyr_plots')\n",
+    "if os.path.exists('incidenceAngle'):\n",
+    "    shutil.rmtree('incidenceAngle')\n",
+    "if os.path.exists('azimuthAngle'):\n",
+    "    shutil.rmtree('azimuthAngle')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "source": [
     "shp    = os.path.join(tutorial_home_dir, 'support_docs', 'Big_Island', 'Big_Island.shp')\n",
-    "!ariaExtract.py -f \"products/*.nc\" -l \"incidenceAngle,azimuthAngle\"  -d download -b {shp}"
+    "!ariaExtract.py -f \"products/*.nc\" -l \"incidenceAngle,azimuthAngle\" -d DEM/glo_90.dem -b {shp}"
    ],
    "outputs": [],
    "metadata": {}

--- a/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/ariaTSsetup_tutorial.ipynb
+++ b/EarthScope2023/3.3_Interferogram_stacks_with_ARIA_tools/ariaTSsetup_tutorial.ipynb
@@ -57,7 +57,7 @@
    "execution_count": null,
    "source": [
     "# option to control the use of pre-staged data; [False/True]\n",
-    "Use_Staged_Data = False\n",
+    "Use_Staged_Data = True\n",
     "\n",
     "# ------------------------------------------------------------------------------------------- #\n",
     "# no changed below needed:\n",


### PR DESCRIPTION
If running in sequence, the first application step will fail without checking for and removing products generated in previous runs